### PR TITLE
Add support for Demagnetize mod and conveyors

### DIFF
--- a/src/main/java/jotato/quantumflux/items/ItemMagnet.java
+++ b/src/main/java/jotato/quantumflux/items/ItemMagnet.java
@@ -68,6 +68,9 @@ public class ItemMagnet extends ItemBase {
 				player.posZ, this.distanceFromPlayer).iterator();
 		while (iterator.hasNext()) {
 			EntityItem itemToGet = (EntityItem) iterator.next();
+			if (itemToGet.getEntityData().getBoolean("PreventRemoteMovement")) {
+				continue;
+			}
 			if(itemToGet.ticksExisted<=1) itemToGet.setPickupDelay(1);
 			itemToGet.onCollideWithPlayer(player);
 		}


### PR DESCRIPTION
**Summary**
Immersive Engineering's conveyors (and [my Demagnetize mod](https://minecraft.curseforge.com/projects/demagnetize)) add the PreventRemoteMovement boolean NBT tag to the item. This prevents them from being picked up by magnets.