### PR TITLE
Fix TileImaginaryTime not being able to extract it's energy requirement

### DIFF
--- a/src/main/java/jotato/quantumflux/machines/imaginarytime/TileImaginaryTime.java
+++ b/src/main/java/jotato/quantumflux/machines/imaginarytime/TileImaginaryTime.java
@@ -21,7 +21,7 @@ public class TileImaginaryTime extends TileBase implements IEnergyReceiver, IEne
 	protected EnergyStorage localEnergyStorage;
 
 	public TileImaginaryTime() {
-		localEnergyStorage = new EnergyStorage(1000, ConfigMan.imaginaryTime_chargeRate);
+		localEnergyStorage = new EnergyStorage(1000, ConfigMan.imaginaryTime_chargeRate, ConfigMan.imaginaryTime_energyRequirement);
 	}
 
 	@Override


### PR DESCRIPTION
**Summary**
The `EnergyStorage` in the `TileImaginaryTime` is constructed with the `maxTransfer` being set to the `chargeRate`, When the Tile goes to extract the energy it's limited by the `maxTransfer`. So if the `energyRequirement` is higher than the `chargeRate` instead of extracting the `energyRequirement` it's getting limited and only extracting the `chargeRate`.

This PR makes it so the `capacity` is 1000, the `maxReceive` is the `chargeRate` and the `maxExtract` is the `energyRequirement`.