### PR TITLE
Make Quibit cells only stack to 1

### DIFF
--- a/src/main/java/jotato/quantumflux/items/ItemQuibitCell.java
+++ b/src/main/java/jotato/quantumflux/items/ItemQuibitCell.java
@@ -20,6 +20,7 @@ public class ItemQuibitCell extends ItemBase {
 		super("quibitCell");
 		canRepair = false;
 		setMaxDamage(0);
+		setMaxStackSize(1);
 	}
 
 	@Override


### PR DESCRIPTION
**Summary**
They don't work when stacked higher anyways, and when you sort your inventory it is super annoying to have to split apart however many you happen to be holding.

**Related issues**
N/A